### PR TITLE
Update use to params pattern

### DIFF
--- a/manifests/docker/params.pp
+++ b/manifests/docker/params.pp
@@ -1,0 +1,1 @@
+class docker_ee_cvd::docker::params inherits docker_ddc::params {}

--- a/manifests/docker/role/ucp/controller/master.pp
+++ b/manifests/docker/role/ucp/controller/master.pp
@@ -1,12 +1,12 @@
 class docker_ee_cvd::docker::role::ucp::controller::master(
-  $username           = $docker_ddc::params::ucp_username,
-  $password           = $docker_ddc::params::ucp_password,
-  $user_access_port   = $docker_ddc::params::controller_port,
-  $version            = $docker_ddc::params::version,
-  $docker_socket_path = $docker_ddc::params::docker_socket_path,
-  $license_file       = $docker_ddc::params::license_file,
-  $external_ca        = $docker_ddc::params::external_ca,
-){
+  $username           = $docker_ee_cvd::docker::params::ucp_username,
+  $password           = $docker_ee_cvd::docker::params::ucp_password,
+  $user_access_port   = $docker_ee_cvd::docker::params::controller_port,
+  $version            = $docker_ee_cvd::docker::params::version,
+  $docker_socket_path = $docker_ee_cvd::docker::params::docker_socket_path,
+  $license_file       = $docker_ee_cvd::docker::params::license_file,
+  $external_ca        = $docker_ee_cvd::docker::params::external_ca,
+) inherits docker_ee_cvd::docker::params {
 
   $controller_ip = $facts['networking']['ip']
 
@@ -20,5 +20,5 @@ class docker_ee_cvd::docker::role::ucp::controller::master(
     external_ca        => $external_ca,
     username           => $username,
     password           => $password,
-    }   
-}  
+    }
+}

--- a/manifests/docker/role/ucp/controller/replica.pp
+++ b/manifests/docker/role/ucp/controller/replica.pp
@@ -1,10 +1,10 @@
 class docker_ee_cvd::docker::role::ucp::controller::replica(
-  $ucp_version         = $docker_ddc::params::version,
+  $ucp_version         = $docker_ee_cvd::docker::params::version,
   $ucp_controller_node = undef,
-  $ucp_controller_port = $docker_ddc::params::controller_port,
-  $token               = $docker_ddc::params::token,
-  $fingerprint         = $docker_ddc::params::fingerprint
-){
+  $ucp_controller_port = $docker_ee_cvd::docker::params::controller_port,
+  $token               = $docker_ee_cvd::docker::params::token,
+  $fingerprint         = $docker_ee_cvd::docker::params::fingerprint
+) inherits docker_ee_cvd::docker::params {
 
  $replica_address = $facts['networking']['ip']
 

--- a/manifests/docker/role/ucp/dtr/master.pp
+++ b/manifests/docker/role/ucp/dtr/master.pp
@@ -1,9 +1,9 @@
 class docker_ee_cvd::docker::role::ucp::dtr::master(
   $ucp_controller_node_ip   = undef,
-  $ucp_controller_node_user = $docker_ddc::params::ucp_username,
-  $ucp_controller_node_pass = $docker_ddc::params::ucp_password,
-  $ucp_controller_node_port = $docker_ddc::params::controller_port,
-){
+  $ucp_controller_node_user = $docker_ee_cvd::docker::params::ucp_username,
+  $ucp_controller_node_pass = $docker_ee_cvd::docker::params::ucp_password,
+  $ucp_controller_node_port = $docker_ee_cvd::docker::params::controller_port,
+) inherits docker_ee_cvd::docker::params {
 
   $dtr_node_ip       = $facts['networking']['ip']
   $dtr_node_hostname = $facts['networking']['fqdn']

--- a/manifests/docker/role/ucp/dtr/replica.pp
+++ b/manifests/docker/role/ucp/dtr/replica.pp
@@ -1,10 +1,10 @@
 class docker_ee_cvd::docker::role::ucp::dtr::replica(
   $ucp_controller_node_ip   = undef,
-  $ucp_controller_node_user = $docker_ddc::params::version,
-  $ucp_controller_node_pass = $docker_ddc::params::ucp_password,
-  $ucp_controller_node_port = $docker_ddc::params::controller_port,
+  $ucp_controller_node_user = $docker_ee_cvd::docker::params::version,
+  $ucp_controller_node_pass = $docker_ee_cvd::docker::params::ucp_password,
+  $ucp_controller_node_port = $docker_ee_cvd::docker::params::controller_port,
   $existing_replica_id      = undef,
-){
+) inherits docker_ee_cvd::docker::params {
 
   $dtr_node_hostname = $facts['networking']['fqdn']
 

--- a/manifests/docker/role/ucp/worker.pp
+++ b/manifests/docker/role/ucp/worker.pp
@@ -1,10 +1,10 @@
 class docker_ee_cvd::docker::role::ucp::worker(
-  $ucp_version         = $docker_ddc::params::version,
+  $ucp_version         = $docker_ee_cvd::docker::params::version,
   $ucp_controller_node = undef,
-  $ucp_controller_port = $docker_ddc::params::controller_port,
-  $token               = $docker_ddc::params::token,
-  $fingerprint         = $docker_ddc::params::fingerprint
-){
+  $ucp_controller_port = $docker_ee_cvd::docker::params::controller_port,
+  $token               = $docker_ee_cvd::docker::params::token,
+  $fingerprint         = $docker_ee_cvd::docker::params::fingerprint
+) inherits docker_ee_cvd::docker::params {
 
   $worker_address = $facts['networking']['ip']
 


### PR DESCRIPTION
  Implements Class[docker_ee_cvd::docker::params] as a wrappter to
  Class[docker_ddc::params] to facilitate the re-use to its default
  values.

  Without this change the majority of default values for various
  parameters will come back undef even if that is not the intention
  because the success of lookup values from Class[docker_ddc::params]
  is order dependent, you would always be required to make sure
  Class[docker_ddc::params] was declared before any docker_ee_cvd
  related classes.