### PR TITLE
Override some default with new defaults

### DIFF
--- a/manifests/docker/params.pp
+++ b/manifests/docker/params.pp
@@ -1,1 +1,6 @@
-class docker_ee_cvd::docker::params inherits docker_ddc::params {}
+class docker_ee_cvd::docker::params inherits docker_ddc::params {
+
+  $ucp_username = 'admin'
+  $ucp_password = 'puppetlabs'
+  $controller_port = '19002'
+}


### PR DESCRIPTION
  This commit adds three variables to params.pp file to be used as local
  defaults as opposed to leveraging the standards inherited from docker_ddc.